### PR TITLE
fix(examples): make Delegate to [PEACE] work when re-delegating

### DIFF
--- a/examples/Delegate Current Address to PEACE (MAINNET).gcscript
+++ b/examples/Delegate Current Address to PEACE (MAINNET).gcscript
@@ -1,6 +1,6 @@
 {
   "title": "Delegate to [PEACE]",
-  "description": "About to delegate your ADA to 'PEACEpool Cardano ecosystem developers' stake pool",
+  "description": "About to delegate your ADA to 'PEACEpool Cardano ecosystem developers' stake pool. The stake key is registered and delegated in a single transaction, and an already registered stake key is handled, so the same script also works when re-delegating.",
   "require": {
     "not": {
       "walletTypeIn": [
@@ -11,6 +11,10 @@
     "networkTag": "mainnet"
   },
   "type": "script",
+  "exportAs": "data",
+  "return": {
+    "mode": "last"
+  },
   "run": {
     "dependencies": {
       "type": "script",
@@ -35,13 +39,6 @@
         "pubKeyHashHex": "{get('cache.dependencies.addressInfo.stakingKeyHash')}"
       }
     },
-    "deregistrationCert": {
-      "type": "certificate",
-      "cert": {
-        "kind": "StakeDeregistration",
-        "pubKeyHashHex": "{get('cache.dependencies.addressInfo.stakingKeyHash')}"
-      }
-    },
     "delegationCert": {
       "type": "certificate",
       "cert": {
@@ -56,37 +53,49 @@
         "buildTransaction": {
           "type": "buildTx",
           "name": "Delegate to [PEACE]",
+          "title": "Delegate to [PEACE]",
           "tx": {
             "certificates": [
               {
-                "certHex": "{get('cache.registrationCert.certHex')}"
+                "certHex": "{get('cache.registrationCert')}"
               },
               {
-                "certHex": "{get('cache.delegationCert.certHex')}"
+                "certHex": "{get('cache.delegationCert')}"
               }
-            ]
+            ],
+            "options": {
+              "autoProvision": {
+                "workspaceNativeScript": true
+              },
+              "autoOptionalSigners": {
+                "nativeScript": true
+              },
+              "autoClean": {
+                "certReRegistrations": true
+              }
+            }
           }
         },
         "signTransaction": {
-          "type": "signTx",
-          "txHex": "{get('cache.txs.buildTransaction.txHex')}"
+          "type": "signTxs",
+          "detailedPermissions": false,
+          "txs": [
+            "{get('cache.txs.buildTransaction.txHex')}"
+          ]
         },
         "submitTransaction": {
-          "type": "submitTx",
-          "later": false,
-          "wait": true,
-          "txHex": "{get('cache.txs.signTransaction.txHex')}"
+          "type": "submitTxs",
+          "txs": "{get('cache.txs.signTransaction')}"
         }
       }
     },
     "finally": {
-      "type": "script",
-      "exportAs": "data",
+      "type": "macro",
       "run": {
-        "txHash": {
-          "type": "macro",
-          "run": "{get('cache.txs.signTransaction.txHash')}"
-        }
+        "address": "{get('cache.dependencies.address')}",
+        "rewardAddress": "{get('cache.dependencies.addressInfo.rewardAddress')}",
+        "stakePoolKeyHash": "{get('cache.dependencies.poolKeyHash')}",
+        "txHash": "{get('cache.txs.buildTransaction.txHash')}"
       }
     }
   }


### PR DESCRIPTION
The transaction always includes a StakeRegistration certificate. On mainnet, anyone re-delegating already has a registered stake key, so the transaction is rejected and the example only ever works once, on a fresh stake key. options.autoClean.certReRegistrations is the option the maintainer added to Stake Delegation in #28 and it fixes the same bug here.

Also, on the last example still using the deprecated API:

- signTx/submitTx -> signTxs/submitTxs
- dead StakeDeregistration block removed: it was built on every run and never referenced, same block that was deleted from Stake Delegation
- {get('cache.registrationCert.certHex')} -> {get('cache.registrationCert')}: a certificate block without extras resolves to the hex itself, matching the merged Stake Delegation
- nested `finally` script flattened into a macro; exportAs kept as "data" so downstream consumers are unaffected, return.mode added
- the result now carries address, rewardAddress and stakePoolKeyHash next to the tx hash

No arguments here on purpose: this demo delegates to one specific pool and Stake Delegation is the parameterized one.


Claude-Session: https://claude.ai/code/session_01WxbXoxULCzvQ63xRfHZaAB