### PR TITLE
feat(examples): modernize Native asset minter and burner DevX

### DIFF
--- a/examples/Native asset minter and burner.gcscript
+++ b/examples/Native asset minter and burner.gcscript
@@ -1,24 +1,45 @@
 {
   "type": "script",
+  "title": "Native asset minter and burner",
+  "description": "Creates a native script and uses it as policy to mint two fungible tokens under it, then burns one of them in a second transaction while the other survives. Asset names and quantities are exposed as flat arguments so an auto-generated dapp can drive the whole run without touching the code, and they are checked with assert() before the wallet builds anything. A GameChanger Wallet Dapp Demo. https://gamechanger.finance/",
+  "exportAs": "MintAndBurn",
+  "return": {
+    "mode": "last"
+  },
+  "args": {
+    "asset-name": "WillDieToken",
+    "mint-quantity": "100",
+    "burn-quantity": "100",
+    "survivor-asset-name": "WillNotDieToken",
+    "survivor-quantity": "1"
+  },
   "run": {
+    "argumentGuards": {
+      "type": "macro",
+      "run": {
+        "asset-name-must-not-be-empty": "{ assert( not(isEmptyString(get('args.asset-name'))) ,'asset-name must not be empty' , get('args') ) }",
+        "survivor-asset-name-must-not-be-empty": "{ assert( not(isEmptyString(get('args.survivor-asset-name'))) ,'survivor-asset-name must not be empty' , get('args') ) }",
+        "asset-names-must-differ": "{ assert( neq(get('args.asset-name'),get('args.survivor-asset-name')) ,'asset-name and survivor-asset-name must differ, otherwise the burn destroys the token this example is meant to keep alive' , get('args') ) }",
+        "mint-quantity-must-be-positive": "{ assert( cmpBigNum('gt',get('args.mint-quantity'),'0') ,'mint-quantity must be greater than zero' , get('args') ) }",
+        "survivor-quantity-must-be-positive": "{ assert( cmpBigNum('gt',get('args.survivor-quantity'),'0') ,'survivor-quantity must be greater than zero' , get('args') ) }",
+        "burn-quantity-must-be-positive": "{ assert( cmpBigNum('gt',get('args.burn-quantity'),'0') ,'burn-quantity must be greater than zero' , get('args') ) }",
+        "burn-quantity-must-not-exceed-mint": "{ assert( cmpBigNum('lte',get('args.burn-quantity'),get('args.mint-quantity')) ,'burn-quantity must not exceed mint-quantity' , get('args') ) }"
+      }
+    },
     "dependencies": {
       "type": "script",
       "run": {
-        "issuer": {
-          "type": "deriveKeys",
-          "keys": [
-            {
-              "name": "issuer",
-              "kind": "spend",
-              "accountIndex": 0,
-              "addressIndex": 0
-            }
-          ]
+        "address": {
+          "type": "getCurrentAddress"
+        },
+        "addressInfo": {
+          "type": "macro",
+          "run": "{getAddressInfo(get('cache.dependencies.address'))}"
         },
         "mintingPolicy": {
           "type": "nativeScript",
           "script": {
-            "pubKeyHashHex": "{get('cache.dependencies.issuer.0.pubKeyHashHex')}"
+            "pubKeyHashHex": "{get('cache.dependencies.addressInfo.paymentKeyHash')}"
           }
         }
       }
@@ -26,18 +47,19 @@
     "buildMint": {
       "type": "buildTx",
       "name": "built-mint",
+      "title": "Native asset minter and burner: mint",
       "tx": {
         "mints": [
           {
             "policyId": "{get('cache.dependencies.mintingPolicy.scriptHashHex')}",
             "assets": [
               {
-                "assetName": "WillDieToken",
-                "quantity": "100"
+                "assetName": "{get('args.asset-name')}",
+                "quantity": "{get('args.mint-quantity')}"
               },
               {
-                "assetName": "WillNotDieToken",
-                "quantity": "1"
+                "assetName": "{get('args.survivor-asset-name')}",
+                "quantity": "{get('args.survivor-quantity')}"
               }
             ]
           }
@@ -65,14 +87,15 @@
     "buildBurn": {
       "type": "buildTx",
       "name": "built-burn",
+      "title": "Native asset minter and burner: burn",
       "tx": {
         "mints": [
           {
             "policyId": "{get('cache.dependencies.mintingPolicy.scriptHashHex')}",
             "assets": [
               {
-                "assetName": "WillDieToken",
-                "quantity": "-100"
+                "assetName": "{get('args.asset-name')}",
+                "quantity": "{subBigNum('0',get('args.burn-quantity'))}"
               }
             ]
           }
@@ -98,29 +121,15 @@
       "txs": "{get('cache.signBurn')}"
     },
     "finally": {
-      "type": "script",
-      "exportAs": "MintAndBurn",
+      "type": "macro",
       "run": {
-        "issuer": {
-          "type": "macro",
-          "run": "{get('cache.dependencies.issuer.0.pubKeyHashHex')}"
-        },
-        "policyId": {
-          "type": "macro",
-          "run": "{get('cache.dependencies.mintingPolicy.scriptHashHex')}"
-        },
-        "policyScript": {
-          "type": "macro",
-          "run": "{get('cache.dependencies.mintingPolicy.scriptHex')}"
-        },
-        "mintTx": {
-          "type": "macro",
-          "run": "{get('cache.submitMint.0')}"
-        },
-        "burnTx": {
-          "type": "macro",
-          "run": "{get('cache.submitBurn.0')}"
-        }
+        "issuer": "{get('cache.dependencies.addressInfo.paymentKeyHash')}",
+        "policyId": "{get('cache.dependencies.mintingPolicy.scriptHashHex')}",
+        "policyScript": "{get('cache.dependencies.mintingPolicy.scriptHex')}",
+        "burnedAssetName": "{get('args.asset-name')}",
+        "survivingAssetName": "{get('args.survivor-asset-name')}",
+        "mintTxHash": "{get('cache.buildMint.txHash')}",
+        "burnTxHash": "{get('cache.buildBurn.txHash')}"
       }
     }
   }


### PR DESCRIPTION
- title and description added: the example was unlabelled in the Playground and in a generated dapp
- issuer key taken from getCurrentAddress + getAddressInfo instead of deriveKeys at account 0 / address 0, same shape as the merged NFT Minting Demo, so the policy still belongs to the wallet under multisig
- asset names and quantities exposed as five flat arguments, guarded with assert(), including burn-quantity <= mint-quantity and asset-name != survivor-asset-name, which would otherwise burn the token the example is meant to keep alive
- the burn quantity was the literal "-100" and had to be kept in sync with the mint quantity by hand; it is now derived with subBigNum so it cannot drift
- nested `finally` script flattened into a macro so it can read args; exportAs and return moved to the root, and the result now reports the burned and surviving asset names next to both tx hashes

assetName (ASCII) kept rather than assetNameHex: this is a minting demo and the readable name is the point, as in NFT Minting Demo.


Claude-Session: https://claude.ai/code/session_01WxbXoxULCzvQ63xRfHZaAB